### PR TITLE
Fix incorrect plugin loading warning log

### DIFF
--- a/ShadowPluginLoader.WinUI/AbstractPluginLoader.cs
+++ b/ShadowPluginLoader.WinUI/AbstractPluginLoader.cs
@@ -144,9 +144,9 @@ public abstract partial class AbstractPluginLoader<TMeta, TAPlugin>
     protected virtual void LoadPlugin(Type plugin, TMeta meta)
     {
         var stopwatch = new Stopwatch();
+        stopwatch.Start();
         try
         {
-            stopwatch.Start();
             BeforeLoadPlugin(plugin, meta);
             var instance = LoadMainPlugin(plugin, meta);
             AfterLoadPlugin(plugin, instance, meta);
@@ -161,15 +161,23 @@ public abstract partial class AbstractPluginLoader<TMeta, TAPlugin>
             if (!enabled) return;
             instance.IsEnabled = enabled;
         }
-        finally
+        catch (Exception e)
         {
             if (stopwatch.IsRunning)
             {
                 stopwatch.Stop();
             }
 
-            Logger.Warning("{Pre}Plugin LoadAsync Failed! Used: {mi} ms",
-                LoggerPrefix, stopwatch.ElapsedMilliseconds);
+            Logger.Warning("{Pre}Plugin LoadAsync Failed! Used: {mi} ms, Error: {Ex}",
+                LoggerPrefix, stopwatch.ElapsedMilliseconds, e);
+            throw;
+        }
+        finally
+        {
+            if (stopwatch.IsRunning)
+            {
+                stopwatch.Stop();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix plugin load warning that logged even on success by moving log to a catch block

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760c0f285c833289d4207b374f76a2 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request improves the plugin loading process by adjusting the logging behavior. The warning log is now only triggered in case of errors, enhancing the clarity of log messages during successful loads.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>